### PR TITLE
Fix formatting in Cypress baseUrl configuration

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'cypress';
 
-const baseUrl = process.env.CI 
-  ? 'http://localhost:4173'  // Preview server port in CI
+const baseUrl = process.env.CI
+  ? 'http://localhost:4173' // Preview server port in CI
   : 'http://localhost:5173'; // Dev server port locally
 
 export default defineConfig({


### PR DESCRIPTION
Adjust the formatting of the baseUrl configuration for improved readability.