### PR TITLE
Configure Vercel deployment for isotope project

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -269,52 +269,52 @@ jobs:
 # Deployment jobs commented out until Vercel setup is ready
 # Uncomment and configure when ready to set up deployments
 
-#  deploy-preview:
-#    name: Deploy Preview (Develop)
-#    if: github.ref == 'refs/heads/develop'
-#    needs: [build]
-#    runs-on: ubuntu-latest
-#    steps:
-#      - name: Checkout repository
-#        uses: actions/checkout@v3
-#      
-#      - name: Download build artifacts
-#        uses: actions/download-artifact@v4
-#        with:
-#          name: build-output
-#          path: dist
-#      
-#      - name: Deploy to Vercel (Preview)
-#        uses: amondnet/vercel-action@v25
-#        with:
-#          vercel-token: ${{ secrets.VERCEL_TOKEN }}
-#          vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
-#          vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
-#          github-token: ${{ secrets.GITHUB_TOKEN }}
-#          vercel-args: '--prod'
-#          alias-domains: |
-#            isotope-dev.yourdomain.com
-
-#  deploy-production:
-#    name: Deploy Production
-#    if: github.ref == 'refs/heads/main'
-#    needs: [build, e2e]
-#    runs-on: ubuntu-latest
-#    steps:
-#      - name: Checkout repository
-#        uses: actions/checkout@v3
-#      
-#      - name: Download build artifacts
-#        uses: actions/download-artifact@v4
-#        with:
-#          name: build-output
-#          path: dist
-#      
-#      - name: Deploy to Vercel (Production)
-#        uses: amondnet/vercel-action@v25
-#        with:
-#          vercel-token: ${{ secrets.VERCEL_TOKEN }}
-#          vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
-#          vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
-#          github-token: ${{ secrets.GITHUB_TOKEN }}
-#          vercel-args: '--prod'
+  deploy-preview:
+    name: Deploy Preview (Develop)
+    if: github.ref == 'refs/heads/develop'
+    needs: [build]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: build-output
+          path: dist
+      
+      - name: Deploy to Vercel (Preview)
+        uses: amondnet/vercel-action@v25
+        with:
+          vercel-token: ${{ secrets.VERCEL_TOKEN }}
+          vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
+          vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          vercel-args: '--prod'
+          alias-domains: |
+            isotope-dev.yourdomain.com
+  deploy-production:
+    name: Deploy Production
+    if: github.ref == 'refs/heads/main'
+    needs: [build, e2e]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: build-output
+          path: dist
+      
+      - name: Deploy to Vercel (Production)
+        uses: amondnet/vercel-action@v25
+        with:
+          vercel-token: ${{ secrets.VERCEL_TOKEN }}
+          vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
+          vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          vercel-args: '--prod'
+          

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,7 +13,7 @@ const App: FC = (): JSX.Element => {
     <div className="min-h-screen bg-gradient-to-b from-blue-50 to-purple-50 p-4">
       <header className="container mx-auto py-8">
         <h1 className="text-4xl font-bold text-center text-primary-700">
-          Isotope: React. Solve. Evolve.
+          Isotope: React.. Solve.. Evolve..
         </h1>
         <p className="text-center text-lg mt-2 text-gray-600">
           An educational puzzle game using the periodic table


### PR DESCRIPTION
Set up Vercel deployment for the isotope project, enabling continuous deployment for the Vite + React + TypeScript application. This includes configuring the GitHub Actions workflow for preview and production deployments, as well as updating the application title in the main component. Fixes #13