### PR TITLE
Remove Unused Custom Domain Configuration from Vercel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -292,8 +292,6 @@ jobs:
           vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           vercel-args: '--prod'
-          alias-domains: |
-            isotope-dev.yourdomain.com
   deploy-production:
     name: Deploy Production
     if: github.ref == 'refs/heads/main'


### PR DESCRIPTION
Remove the unused custom domain configuration from the Vercel deployment settings to maintain clean and accurate deployment configurations. This change ensures that the application continues to deploy correctly to the default Vercel domain without any confusion regarding custom domains.

Fixes #28